### PR TITLE
Adds Predator Alert questions as a new category 'predator'

### DIFF
--- a/plugin/questions/predator.js
+++ b/plugin/questions/predator.js
@@ -1,0 +1,140 @@
+// questions from here:
+// github.com/meitar/pat-okcupid/blob/master/okcupid-predator-alert-tool.user.js
+
+_OKCP.fileQuestions.discrimination =
+	{
+		"predatory": [
+			{
+				"qid":"421567",
+				"text":"Have you ever punched or kicked or repeatedly slapped with an open hand (e.g., two or more times in a single incident) someone who you were in some kind of intimate relationship with?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"423365",
+				"text":"Have you ever choked someone who you were in some kind of intimate relationship with (e.g., you wrapped your hands or some object around their throat)?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421568",
+				"text":"Have you ever beat a child with your fists or with an object (e.g., a stick, bat, etc.)? Have you ever deliberately burned or scalded a child?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421570",
+				"text":"Have you ever fondled (e.g., handled, massaged, caressed) a child's genitals or had them fondle yours?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421572",
+				"text":"Have you ever had oral sex with a child—e.g., either you performed oral sex on them, or they on you, or both?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421574",
+				"text":"Have you ever been in a situation where you tried, but for various reasons did not succeed, in having sexual intercourse with an adult by using or threatening to use physical force (twisting their arm, holding them down—etc) if they didn't cooperate?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421577",
+				"text":"Have you ever had sexual intercourse with someone, even though they did not want to, because they were too intoxicated (on alcohol or drugs) to resist your sexual advances (e.g., removing their clothes)?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"423366",
+				"text":"Have you ever had sexual intercourse with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"423369",
+				"text":"Have you ever had oral sex with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"430229",
+				"text":"Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by giving her alcohol or drugs but you did NOT succeed?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"428187",
+				"text":"Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by giving her alcohol or drugs or getting her high or drunk?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"428188",
+				"text":"Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by threatening or using some degree of force but you did NOT succeed?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"430230",
+				"text":"Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by using some degree of force or threatening to harm her?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"430232",
+				"text":"Have you made a female do other sexual things like anal sex, oral sex, or putting fingers or objects inside of her or you by using some degree of force or threatening to harm her?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"21527",
+				"text":"Do you feel there are any circumstances in which a person is obligated to have sex with you?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"19162",
+				"text":"No means NO!",
+				"answerText": ["Always. Period.", "Mostly, occasionally it's really a Yes in disguise", "A No is just a Yes that needs a little convincing!", "Never, they all want me. They just don't know it."],
+				"score": [1, -1, -1, -1]
+			},
+			{
+				"qid":"8218",
+				"text":"Would you ever film a sexual encounter without your partner knowing?",
+				"answerText": ["Yes", "No", "I'm Not Sure"],
+				"score": [-1, 1, -1]
+			},
+			{
+				"qid":"55349",
+				"text":"Have you ever thrown an object in anger during an argument?",
+				"answerText": ["Yes.", "No."],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"36624",
+				"text":"Are you ever violent with your friends?",
+				"answerText": ["Yes, I use physical force whenever I want.", "Yes, but only where appropriate in competition.", "Yes, but only playfully or in jest.", "No, violence is never fun."],
+				"score": [-1, 1, -1, 1]
+			},
+			{
+				"qid":"48947",
+				"text":"Is intoxication ever an acceptable excuse for acting stupid?",
+				"answerText": ["Yes.", "No."],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"461985",
+				"text":"Rolequeer play sounds...",
+				"answerText": ["...super hot!", "...kind of interesting but I'm not sure.", "...like a bad joke.", "I don't know what this is."],
+				"score": [1, 1, -1, 1]
+			},
+			{
+				"qid":"461987",
+				"text":"My favorite kinky power dynamic is:",
+				"answerText": ["D/s: Dominant/submissive", "D/D: Dominant/Dominant", "s/s: submissive/submissive", "I'm too rolequeer for any of these."],
+				"score": [-1, -1, 1, 1]
+			},
+		]
+	};


### PR DESCRIPTION
See http://maybemaimed.com/playground/predator-alert-tool-for-okcupid/ for details on Predator Alert.

"The Predator Alert Tool for OkCupid (PAT-OKC) is an add-on to your Web browser that alerts of you of any red flags for a given profile as you browse OkCupid. "

That add-on is heavyweight, not particularly robust, and fails to run on some systems. It also visits profiles of other users without permission, in what appears to be some kind of data-gathering initiative. In addition, it takes profile pictures and does facial recognition(!) against the US sex offenders registry(!!). Entirely apart from usability issues, I have deep concerns about the data-gathering and the risk of false positives with that facial recognition system.

To the best of my knowledge, I am not reproducing any of the Predator Alert developer's original work; these questions are either sourced from a study by Lisak and Miller, or pre-existing OkCupid questions.