### PR TITLE
Sanitize shockwave's pull request to add Predator Alert questions as a new category 'predator'

### DIFF
--- a/plugin/-category-list.mdown
+++ b/plugin/-category-list.mdown
@@ -49,6 +49,9 @@ discrimination
 	disability
 	weight
 
+predator
+	predator
+
 other
 	artist
 	non-artist

--- a/plugin/features/changeCategories.js
+++ b/plugin/features/changeCategories.js
@@ -6,12 +6,24 @@ _OKCP.changeCategories = function(){
 	showCategorySorter();
 
 	function showCategorySorter () {
-		$('body').append('<div class="categories-lists-wrapper"><div class="categories-lists"><ul class="active-categories categories-list"></ul><ul class="available-categories categories-list"></ul><input id="save-category-changes" type="button" value="Save Changes"><input id="cancel-category-changes" type="button" value="Cancel"><input id="reset-categories" type="button" value="Reset Categories"></div></div>');
+		$('body').append(
+			'<div class="categories-lists-wrapper">' +
+			'<div class="categories-lists">' +
+			'<ul class="active-categories categories-list">' +
+			'</ul>' +
+			'<ul class="available-categories categories-list">' +
+			'</ul><input id="save-category-changes" type="button" value="Save Changes">' +
+			'<input id="cancel-category-changes" type="button" value="Cancel">' +
+			'<input id="reset-categories" type="button" value="Reset Categories">' +
+			'</div>' +
+			'</div>');
+
 		$.each(_OKCP.categoryList, function(i, value){
 			var valueReadable = value.split('_').join(' ');
-			if ($.inArray(value,currCategories) >= 0) {
+			if ($.inArray(value, currCategories) >= 0) {
 				$('.active-categories').append('<li>' + valueReadable + '</li>');
 			} else {
+				console.log(valueReadable);
 				$('.available-categories').append('<li>' + valueReadable + '</li>');
 			}
 		});

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -13,7 +13,12 @@
     "default_popup": "options.html"
   },
   "permissions": [
-    "storage", "idle", "notifications", "unlimitedStorage", "http://*.okcupid.com/*", "https://*.okcupid.com/*"
+    "storage",
+    "idle",
+    "notifications",
+    "unlimitedStorage",
+    "http://*.okcupid.com/*",
+    "https://*.okcupid.com/*"
   ],
   "background": {
     "scripts": ["features/eventPage.js"],
@@ -21,17 +26,20 @@
   },
   "content_scripts": [
     {
-      "matches": ["http://*.okcupid.com/*","https://*.okcupid.com/*"],
+      "matches": [
+        "http://*.okcupid.com/*",
+        "https://*.okcupid.com/*"
+      ],
       "css": [
-				"lib/ui-lightness/jquery-ui-1.10.3.custom.css"
-				, "style.css"
-			],
+        "lib/ui-lightness/jquery-ui-1.10.3.custom.css",
+        "style.css"
+      ],
       "js": [
-				"lib/knockout/build/output/knockout-latest.js",
-				"lib/jquery/jquery.min.js",
-				"lib/jqueryui/ui/minified/jquery-ui.min.js",
-				"lib/loglevel/dist/loglevel.min.js",
-				"lib/bootstrap/dist/js/bootstrap.min.js",
+        "lib/knockout/build/output/knockout-latest.js",
+        "lib/jquery/jquery.min.js",
+        "lib/jqueryui/ui/minified/jquery-ui.min.js",
+        "lib/loglevel/dist/loglevel.min.js",
+        "lib/bootstrap/dist/js/bootstrap.min.js",
         "setup.js",
         "settings.js",
         "storage.js",
@@ -59,11 +67,12 @@
         "features/messageSearch.js",
         "getAnswers.js",
         "ViewModels.js",
-        "init.js"],
+        "init.js"
+      ],
       "run_at": "document_end"
     }
   ],
-  "web_accessible_resources":  [
+  "web_accessible_resources": [
     "images/ajax-loader.gif",
     "images/icon-128.png",
     "lib/jquery/jquery.min.map"

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "OkCupid (for the Non-Mainstream User)",
   "short_name": "OkC Alt",
-  "version": "2.8.12",
+  "version": "2.8.13",
   "manifest_version": 2,
   "description": "Are you using OkCupid? You should definitely be using this extension.",
   "homepage_url": "http://benjaffe.me/projects/date/",
@@ -49,6 +49,7 @@
         "questions/children.js",
         "questions/demeanor.js",
         "questions/discrimination.js",
+        "questions/predator.js",
         "questions/drugs_smokes.js",
         "questions/other.js",
         "questions/relationship_model.js",

--- a/plugin/questions-init.js
+++ b/plugin/questions-init.js
@@ -1,6 +1,6 @@
 
 var questions = {
-	"questionsVersionNum": "1.5.0",
+	"questionsVersionNum": "1.6.0",
 	"questionsList": []
 };
 

--- a/plugin/questions/predator.js
+++ b/plugin/questions/predator.js
@@ -1,0 +1,140 @@
+// questions from here:
+// github.com/meitar/pat-okcupid/blob/master/okcupid-predator-alert-tool.user.js
+
+_OKCP.fileQuestions.discrimination =
+	{
+		"predatory": [
+			{
+				"qid":"421567",
+				"text":"Have you ever punched or kicked or repeatedly slapped with an open hand (e.g., two or more times in a single incident) someone who you were in some kind of intimate relationship with?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"423365",
+				"text":"Have you ever choked someone who you were in some kind of intimate relationship with (e.g., you wrapped your hands or some object around their throat)?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421568",
+				"text":"Have you ever beat a child with your fists or with an object (e.g., a stick, bat, etc.)? Have you ever deliberately burned or scalded a child?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421570",
+				"text":"Have you ever fondled (e.g., handled, massaged, caressed) a child's genitals or had them fondle yours?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421572",
+				"text":"Have you ever had oral sex with a child—e.g., either you performed oral sex on them, or they on you, or both?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421574",
+				"text":"Have you ever been in a situation where you tried, but for various reasons did not succeed, in having sexual intercourse with an adult by using or threatening to use physical force (twisting their arm, holding them down—etc) if they didn't cooperate?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"421577",
+				"text":"Have you ever had sexual intercourse with someone, even though they did not want to, because they were too intoxicated (on alcohol or drugs) to resist your sexual advances (e.g., removing their clothes)?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"423366",
+				"text":"Have you ever had sexual intercourse with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"423369",
+				"text":"Have you ever had oral sex with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"430229",
+				"text":"Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by giving her alcohol or drugs but you did NOT succeed?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"428187",
+				"text":"Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by giving her alcohol or drugs or getting her high or drunk?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"428188",
+				"text":"Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by threatening or using some degree of force but you did NOT succeed?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"430230",
+				"text":"Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by using some degree of force or threatening to harm her?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"430232",
+				"text":"Have you made a female do other sexual things like anal sex, oral sex, or putting fingers or objects inside of her or you by using some degree of force or threatening to harm her?",
+				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+				"score": [-1, -1, -1, 1]
+			},
+			{
+				"qid":"21527",
+				"text":"Do you feel there are any circumstances in which a person is obligated to have sex with you?",
+				"answerText": ["Yes", "No"],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"19162",
+				"text":"No means NO!",
+				"answerText": ["Always. Period.", "Mostly, occasionally it's really a Yes in disguise", "A No is just a Yes that needs a little convincing!", "Never, they all want me. They just don't know it."],
+				"score": [1, -1, -1, -1]
+			},
+			{
+				"qid":"8218",
+				"text":"Would you ever film a sexual encounter without your partner knowing?",
+				"answerText": ["Yes", "No", "I'm Not Sure"],
+				"score": [-1, 1, -1]
+			},
+			{
+				"qid":"55349",
+				"text":"Have you ever thrown an object in anger during an argument?",
+				"answerText": ["Yes.", "No."],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"36624",
+				"text":"Are you ever violent with your friends?",
+				"answerText": ["Yes, I use physical force whenever I want.", "Yes, but only where appropriate in competition.", "Yes, but only playfully or in jest.", "No, violence is never fun."],
+				"score": [-1, 1, -1, 1]
+			},
+			{
+				"qid":"48947",
+				"text":"Is intoxication ever an acceptable excuse for acting stupid?",
+				"answerText": ["Yes.", "No."],
+				"score": [-1, 1]
+			},
+			{
+				"qid":"461985",
+				"text":"Rolequeer play sounds...",
+				"answerText": ["...super hot!", "...kind of interesting but I'm not sure.", "...like a bad joke.", "I don't know what this is."],
+				"score": [1, 1, -1, 1]
+			},
+			{
+				"qid":"461987",
+				"text":"My favorite kinky power dynamic is:",
+				"answerText": ["D/s: Dominant/submissive", "D/D: Dominant/Dominant", "s/s: submissive/submissive", "I'm too rolequeer for any of these."],
+				"score": [-1, -1, 1, 1]
+			},
+		]
+	};

--- a/plugin/questions/predator.js
+++ b/plugin/questions/predator.js
@@ -2,139 +2,139 @@
 // github.com/meitar/pat-okcupid/blob/master/okcupid-predator-alert-tool.user.js
 
 _OKCP.fileQuestions.discrimination =
-	{
-		"predatory": [
-			{
-				"qid":"421567",
-				"text":"Have you ever punched or kicked or repeatedly slapped with an open hand (e.g., two or more times in a single incident) someone who you were in some kind of intimate relationship with?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"423365",
-				"text":"Have you ever choked someone who you were in some kind of intimate relationship with (e.g., you wrapped your hands or some object around their throat)?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"421568",
-				"text":"Have you ever beat a child with your fists or with an object (e.g., a stick, bat, etc.)? Have you ever deliberately burned or scalded a child?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"421570",
-				"text":"Have you ever fondled (e.g., handled, massaged, caressed) a child's genitals or had them fondle yours?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"421572",
-				"text":"Have you ever had oral sex with a child—e.g., either you performed oral sex on them, or they on you, or both?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"421574",
-				"text":"Have you ever been in a situation where you tried, but for various reasons did not succeed, in having sexual intercourse with an adult by using or threatening to use physical force (twisting their arm, holding them down—etc) if they didn't cooperate?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"421577",
-				"text":"Have you ever had sexual intercourse with someone, even though they did not want to, because they were too intoxicated (on alcohol or drugs) to resist your sexual advances (e.g., removing their clothes)?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"423366",
-				"text":"Have you ever had sexual intercourse with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"423369",
-				"text":"Have you ever had oral sex with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"430229",
-				"text":"Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by giving her alcohol or drugs but you did NOT succeed?",
-				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
-				"score": [-1, -1, -1, 1]
-			},
-			{
-				"qid":"428187",
-				"text":"Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by giving her alcohol or drugs or getting her high or drunk?",
-				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
-				"score": [-1, -1, -1, 1]
-			},
-			{
-				"qid":"428188",
-				"text":"Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by threatening or using some degree of force but you did NOT succeed?",
-				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
-				"score": [-1, -1, -1, 1]
-			},
-			{
-				"qid":"430230",
-				"text":"Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by using some degree of force or threatening to harm her?",
-				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
-				"score": [-1, -1, -1, 1]
-			},
-			{
-				"qid":"430232",
-				"text":"Have you made a female do other sexual things like anal sex, oral sex, or putting fingers or objects inside of her or you by using some degree of force or threatening to harm her?",
-				"answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
-				"score": [-1, -1, -1, 1]
-			},
-			{
-				"qid":"21527",
-				"text":"Do you feel there are any circumstances in which a person is obligated to have sex with you?",
-				"answerText": ["Yes", "No"],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"19162",
-				"text":"No means NO!",
-				"answerText": ["Always. Period.", "Mostly, occasionally it's really a Yes in disguise", "A No is just a Yes that needs a little convincing!", "Never, they all want me. They just don't know it."],
-				"score": [1, -1, -1, -1]
-			},
-			{
-				"qid":"8218",
-				"text":"Would you ever film a sexual encounter without your partner knowing?",
-				"answerText": ["Yes", "No", "I'm Not Sure"],
-				"score": [-1, 1, -1]
-			},
-			{
-				"qid":"55349",
-				"text":"Have you ever thrown an object in anger during an argument?",
-				"answerText": ["Yes.", "No."],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"36624",
-				"text":"Are you ever violent with your friends?",
-				"answerText": ["Yes, I use physical force whenever I want.", "Yes, but only where appropriate in competition.", "Yes, but only playfully or in jest.", "No, violence is never fun."],
-				"score": [-1, 1, -1, 1]
-			},
-			{
-				"qid":"48947",
-				"text":"Is intoxication ever an acceptable excuse for acting stupid?",
-				"answerText": ["Yes.", "No."],
-				"score": [-1, 1]
-			},
-			{
-				"qid":"461985",
-				"text":"Rolequeer play sounds...",
-				"answerText": ["...super hot!", "...kind of interesting but I'm not sure.", "...like a bad joke.", "I don't know what this is."],
-				"score": [1, 1, -1, 1]
-			},
-			{
-				"qid":"461987",
-				"text":"My favorite kinky power dynamic is:",
-				"answerText": ["D/s: Dominant/submissive", "D/D: Dominant/Dominant", "s/s: submissive/submissive", "I'm too rolequeer for any of these."],
-				"score": [-1, -1, 1, 1]
-			},
-		]
-	};
+{
+    "predator": [
+        {
+            "qid": "421567",
+            "text": "Have you ever punched or kicked or repeatedly slapped with an open hand (e.g., two or more times in a single incident) someone who you were in some kind of intimate relationship with?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "423365",
+            "text": "Have you ever choked someone who you were in some kind of intimate relationship with (e.g., you wrapped your hands or some object around their throat)?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "421568",
+            "text": "Have you ever beat a child with your fists or with an object (e.g., a stick, bat, etc.)? Have you ever deliberately burned or scalded a child?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "421570",
+            "text": "Have you ever fondled (e.g., handled, massaged, caressed) a child's genitals or had them fondle yours?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "421572",
+            "text": "Have you ever had oral sex with a child—e.g., either you performed oral sex on them, or they on you, or both?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "421574",
+            "text": "Have you ever been in a situation where you tried, but for various reasons did not succeed, in having sexual intercourse with an adult by using or threatening to use physical force (twisting their arm, holding them down—etc) if they didn't cooperate?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "421577",
+            "text": "Have you ever had sexual intercourse with someone, even though they did not want to, because they were too intoxicated (on alcohol or drugs) to resist your sexual advances (e.g., removing their clothes)?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "423366",
+            "text": "Have you ever had sexual intercourse with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "423369",
+            "text": "Have you ever had oral sex with an adult when they didn't want to because you used or threatened to use physical force (twisting their arm; holding them down, etc.) if they didn't cooperate?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "430229",
+            "text": "Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by giving her alcohol or drugs but you did NOT succeed?",
+            "answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+            "score": [-1, -1, -1, 1]
+        },
+        {
+            "qid": "428187",
+            "text": "Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by giving her alcohol or drugs or getting her high or drunk?",
+            "answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+            "score": [-1, -1, -1, 1]
+        },
+        {
+            "qid": "428188",
+            "text": "Have you attempted to have sexual intercourse with a female (tried to insert your penis in her vagina) when she didn't want to by threatening or using some degree of force but you did NOT succeed?",
+            "answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+            "score": [-1, -1, -1, 1]
+        },
+        {
+            "qid": "430230",
+            "text": "Have you made a female have sexual intercourse (putting all or part of your penis in her vagina even if you didn't ejaculate or come) by using some degree of force or threatening to harm her?",
+            "answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+            "score": [-1, -1, -1, 1]
+        },
+        {
+            "qid": "430232",
+            "text": "Have you made a female do other sexual things like anal sex, oral sex, or putting fingers or objects inside of her or you by using some degree of force or threatening to harm her?",
+            "answerText": ["Yes, once.", "Yes, a few times. (2 to 4 attempts.)", "Yes, many times. (5 or more attempts.)", "No"],
+            "score": [-1, -1, -1, 1]
+        },
+        {
+            "qid": "21527",
+            "text": "Do you feel there are any circumstances in which a person is obligated to have sex with you?",
+            "answerText": ["Yes", "No"],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "19162",
+            "text": "No means NO!",
+            "answerText": ["Always. Period.", "Mostly, occasionally it's really a Yes in disguise", "A No is just a Yes that needs a little convincing!", "Never, they all want me. They just don't know it."],
+            "score": [1, -1, -1, -1]
+        },
+        {
+            "qid": "8218",
+            "text": "Would you ever film a sexual encounter without your partner knowing?",
+            "answerText": ["Yes", "No", "I'm Not Sure"],
+            "score": [-1, 1, -1]
+        },
+        {
+            "qid": "55349",
+            "text": "Have you ever thrown an object in anger during an argument?",
+            "answerText": ["Yes.", "No."],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "36624",
+            "text": "Are you ever violent with your friends?",
+            "answerText": ["Yes, I use physical force whenever I want.", "Yes, but only where appropriate in competition.", "Yes, but only playfully or in jest.", "No, violence is never fun."],
+            "score": [-1, 1, -1, 1]
+        },
+        {
+            "qid": "48947",
+            "text": "Is intoxication ever an acceptable excuse for acting stupid?",
+            "answerText": ["Yes.", "No."],
+            "score": [-1, 1]
+        },
+        {
+            "qid": "461985",
+            "text": "Rolequeer play sounds...",
+            "answerText": ["...super hot!", "...kind of interesting but I'm not sure.", "...like a bad joke.", "I don't know what this is."],
+            "score": [1, 1, -1, 1]
+        },
+        {
+            "qid": "461987",
+            "text": "My favorite kinky power dynamic is:",
+            "answerText": ["D/s: Dominant/submissive", "D/D: Dominant/Dominant", "s/s: submissive/submissive", "I'm too rolequeer for any of these."],
+            "score": [-1, -1, 1, 1]
+        }
+    ]
+};

--- a/plugin/questions/predator.js
+++ b/plugin/questions/predator.js
@@ -1,7 +1,7 @@
 // questions from here:
 // github.com/meitar/pat-okcupid/blob/master/okcupid-predator-alert-tool.user.js
 
-_OKCP.fileQuestions.discrimination =
+_OKCP.fileQuestions.predator =
 {
     "predator": [
         {

--- a/plugin/setup.js
+++ b/plugin/setup.js
@@ -44,14 +44,14 @@ if (_OKCP.profilePath === '') {
 	// create a database if there isn't one
 	if (localStorage.okcp === undefined) {
 		localStorage.okcp = JSON.stringify({
-			dataModelVersion: '1.1.40',
+			dataModelVersion: '1.2.40',
 			profileList: {},
 			settings: {}
 		});
 	}
 
 	var storage = JSON.parse(localStorage.okcp);
-	storage.dataCleanupJobNumToReach = '2.3.0';
+	storage.dataCleanupJobNumToReach = '2.4.0';
 
 	if (storage.dataCleanupJobNum === storage.dataCleanupJobNumToReach) {
 		return false;
@@ -86,14 +86,14 @@ if (_OKCP.profilePath === '') {
 	if (storage.hiddenProfileList !== undefined) {
 		var oldData = storage;
 		var newData = {
-			'dataModelVersion': '1.1.0',
+			'dataModelVersion': '1.2.0',
 			'profileList': {}
 		};
 		for (i=0; i < oldData.hiddenProfileList.length; i++) {
 			newData.profileList[oldData.hiddenProfileList[i]] = {h:true};
 		}
 		localStorage.okcp = JSON.stringify(newData);
-		upgradeMessage.push('  * Updated Data Model to Version 1.1.0');
+		upgradeMessage.push('  * Updated Data Model to Version 1.2.0');
 	}
 
 	storage.dataCleanupJobNum = storage.dataCleanupJobNumToReach;


### PR DESCRIPTION
I wanted to make the requested changes to the stalling [pull request](https://github.com/benjaffe/chrome-okc-plugin/pull/109) #109 of @shokwave to add the predator category.

It was said there that change to the `manifest.json` should suffice, yet reality was a bit different ;) I had to do a bit more to get the predator category to show and I would like some feedback on my current progress.

There is one issue I am still getting as of yet, which I cannot figure out: Often at the first page load of a profile, the number of the predator count is shown as `NaN`. On reloads it will be calculated correctly, and I have seen the number add up.

BTW: I apologize for refactoring so much in the process, it did made debugging easier. Please let me know if you would want to include those changes as well, or if I only shall add necessary changes as a separate pull request.