### PR TITLE
Fix missing comma in nerdy questions

### DIFF
--- a/plugin/questions/nerdy.js
+++ b/plugin/questions/nerdy.js
@@ -104,7 +104,7 @@ _OKCP.fileQuestions.nerdy =
       "score": [1, -1],
       "weight": [1, 1]
     }
-  ]
+  ],
   "video_gamer": [
     {
       "qid": "37693",


### PR DESCRIPTION
`nerdy.js` was missing a comma, and therefore wasn't being loaded.

Now the `programmer`, `enjoys_board_games`, `well_read`, and `video_gamer` categories actually show up in the plugin menu. :)