### PR TITLE
Prevent nav tab dropdowns from being covered by A-list banner

### DIFF
--- a/plugin/style.css
+++ b/plugin/style.css
@@ -1163,6 +1163,7 @@ body#p_profile .tabbed_heading #actions .action_options .flatbutton {
   bottom: 0px;
   left: 50%;
   margin-left: 170px;
+  z-index: 50;
 }
 
 #okcp .okcp-pagetab-item {


### PR DESCRIPTION
When you have visitors disabled, you get this banner promoting an A-list subscription:

![image](https://cloud.githubusercontent.com/assets/735119/16077698/ffc0113c-332c-11e6-8754-6cfe04d7da30.png)

This unfortunately gets in the way of the drop down menus of the tabs when the mouse crosses said banner.

![rollover-problem-okcp](https://cloud.githubusercontent.com/assets/735119/16077955/846b6214-332e-11e6-87ee-1bf35f6b98f0.gif)

This PR fixes the problem.