### PR TITLE
adding a line about bower to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ When you clone the repository you'll need to build it using the grunt file. You'
 
 ``` 
 npm install
+bower install
 ```
 
 Depending on your local environment you may need to run as an administrator.


### PR DESCRIPTION
Just pulled the extension again (haha the benefits of being single again) and noticed you need to run bower now it seems, so added to the readme. Let me know if I'm wrong, seemed like Bower installed Bootstrap and whatnot.